### PR TITLE
ADD: node.prop accept any value for $prop (no filter after plugins)

### DIFF
--- a/lib/cssobj-core.js
+++ b/lib/cssobj-core.js
@@ -284,7 +284,7 @@ function parseProp (node, d, key, result, propKey) {
         rawVal,
         true
       )
-      if (isValidCSSValue(val)) {
+      if (propName.charAt(0)=='$' || isValidCSSValue(val)) {
         // only valid val can enter node.prop and lastVal
         // push every val to prop
         arrayKV(


### PR DESCRIPTION
Whether allow node.prop accept invalid CSS if it's start with $, see issue:

https://github.com/cssobj/cssobj/issues/7
